### PR TITLE
remove deprecated check

### DIFF
--- a/FPDF.php
+++ b/FPDF.php
@@ -180,10 +180,6 @@ class FPDF
         if (ini_get('mbstring.func_overload') & 2) {
             $this->Error('mbstring overloading must be disabled');
         }
-        // Ensure runtime magic quotes are disabled
-        if (get_magic_quotes_runtime()) {
-            @set_magic_quotes_runtime(0);
-        }
     }
 
     function Error($msg)


### PR DESCRIPTION
Magic quotes check is deprecated in php7.4, remove check to ensure php8 compatibility.